### PR TITLE
Migrate to MyAEGEE API

### DIFF
--- a/server/main.js
+++ b/server/main.js
@@ -28,14 +28,14 @@ Meteor.startup(() => {
 
 	// Fetch up-to-date bodies
 	console.log("Fetching bodies");
-	HTTP.get("https://www.locals.aegee.org/locals.json", {}, (err, response) => {
+	HTTP.get("https://my.aegee.eu/services/oms-core-elixir/api/bodies", {}, (err, response) => {
 		if (err) {
 			console.error("Error getting bodies data:", err);
 		} else {
 			bodies = {}
 			let data = JSON.parse(response.content);
-			for (let body of data.Bodies) {
-				bodies[body.BodyCode] = body.BodyName;
+			for (let body of data.data) {
+				bodies[body.legacy_key] = body.name;
 			}
 			// console.log('Bodies set to', bodies);
 		}


### PR DESCRIPTION
I'm taking care of switching all the IT systems in AEGEE to use MyAEGEE instead of the intranet, so this PR is meant to change the bodies fetching from intranet to MyAEGEE.

This serves 2 points:
1) once the intranet isn't used by anything we can finally get rid of it
2) afaik the up-to-date bodies list is in MyAEGEE only, the intranet one can be not up-to-date and some bodies can be missing.