### PR TITLE
fix: upload password param in settings

### DIFF
--- a/private/settings.example.json
+++ b/private/settings.example.json
@@ -6,7 +6,7 @@
 	"password": "admin-pass",
 	"email": "admin-email",
 	"agora-name": "Enschede",
-	"upload-password": "public-password",
+	"upload_password": "public_password",
 	"timeslots": {
 		"2017-02-23": [
 			"0900-1300",


### PR DESCRIPTION
The tool was returning "invalid password" when uploading.

@serge1peshcoff did some research and found [here](https://github.com/AEGEE/AgoraUpload/blob/1d2a5134be1cd9c771b113ff19d27ad0d1e09eae/lib/Submission.js#L171) it was checking for `upload_password` instead of `upload-password` in the configuration file.

@lesteenman can you check this change?