### PR TITLE
fix: avoid file name error with fordward slashes

### DIFF
--- a/lib/Submission.js
+++ b/lib/Submission.js
@@ -4,7 +4,7 @@ const Submissions = new Mongo.Collection('submissions');
 
 function getFileName(sub) {
 	let timeslot = sub.timeslot ? sub.timeslot : 'unknown';
-	return '['+timeslot+']['+sub.body+'] ' + sub.title;
+	return '['+timeslot+']['+sub.body+'] ' + sub.title.replace(/\\/g, ' ');
 }
 
 const maxLengthValidation = {


### PR DESCRIPTION
If an user uploads a file whose name includes a fordward slash (`/`), the tool breaks, as it a special symbol (the name is treated as `folder/file`) with UNIX FileSystems. It is solved by __replacing the `/` symbol with an empty space__.

This broke during this Agora in production, as somebody uploaded a file with this symbol.

Thanks to @serge1peshcoff for finding the problem.